### PR TITLE
Fix: Configure Vite for Vercel deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/src/assets/logo.svg" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Qadeer | Portfolio</title>
   </head>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,5 @@ import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "/my-portfolio/",
   plugins: [react()],
 });


### PR DESCRIPTION
- I removed `base: "/my-portfolio/"` from `vite.config.js` to ensure correct asset pathing on Vercel, which serves from the root.
- I updated the favicon path in `index.html` from `/src/assets/logo.svg` to `/logo.svg` to correctly reference the asset from the public directory.

These changes address the issue of a blank white screen when deploying to Vercel by ensuring assets are loaded correctly.